### PR TITLE
Recursion fix and room bytes count corrected

### DIFF
--- a/Ragon/Sources/Entity/EntityState.cs
+++ b/Ragon/Sources/Entity/EntityState.cs
@@ -11,13 +11,15 @@ public class EntityState
 
   public byte[] Data
   {
-    get => Data;
+    get => _data;
     set
     {
-      Data = value;
+      _data = value;
       isDirty = true;
     }
   }
+
+  private byte[] _data = Array.Empty<byte>();
   
   public EntityState(RagonAuthority ragonAuthority)
   {

--- a/Ragon/Sources/Rooms/Room.cs
+++ b/Ragon/Sources/Rooms/Room.cs
@@ -269,7 +269,7 @@ namespace Ragon.Core
           foreach (var entity in _entities.Values)
           {
             var entityState = entity.State.Data.AsSpan();
-            var data = new byte[entity.State.Data.Length + 12];
+            var data = new byte[entity.State.Data.Length + 14];
 
             Span<byte> sendData = data.AsSpan();
             Span<byte> operationData = sendData.Slice(0, 2);


### PR DESCRIPTION
Fixes:
1. In **EntityState** there was recursion call which caused StackOverflow on player connect. Fixed by introducing new private variable and writing data to it.
2. In **Room.ProcessEvent** was set wrong byte size for byte array handling. Fixed it by setting 14 instead of 12.